### PR TITLE
otp-test-wrapper.sh: Prevent division-by-zero error when file has no executable lines.

### DIFF
--- a/fw.local/template/erlang/tests/otp-test-wrapper.sh
+++ b/fw.local/template/erlang/tests/otp-test-wrapper.sh
@@ -78,11 +78,11 @@ esac
 
 find . -name '*.COVER.out' -and -newer .flass -print | \
   perl -MIO::File -lne 'chomp;
-                       $fh = new IO::File $_, "r" or die $!;
+                       my $fh = new IO::File $_, "r" or die $!;
                        my @total_lines = grep { ! / 0\.\.\|  -module \(/ } <$fh>;
                        my @covered_lines = grep {/[0-9]+\.\./} @total_lines;
                        my $bad = grep / 0\.\.\|/, @total_lines;
                        my $total = scalar @total_lines;
                        my $total_covered = scalar @covered_lines;
-                       my $perc = int (100 * (1.0 - ($bad / $total_covered)));
+                       my $perc = $total_covered > 0 ? int(100 * (1.0 - ($bad / $total_covered))) : "-";
                        print "$perc% of $total lines covered in $_"'


### PR DESCRIPTION
If a source file has zero lines of executable code (one that only defines a behaviour, for example), otp-test-wrapper.sh dies with a division-by-zero error, preventing the package from being built.

I tried to build a test package with my changes, but "make package" failed:

```
Making check in tests
FAIL: test-template
FAIL: test-hooks
PASS: test-oldrecord.sh
```
