### PR TITLE
Cleanup HTML code coverage files for "make clean"

### DIFF
--- a/fw.local/template/erlang/tests/Makefile_dot_am
+++ b/fw.local/template/erlang/tests/Makefile_dot_am
@@ -8,6 +8,7 @@ CLEANFILES = 			\
   $(wildcard module-*) 		\
   $(wildcard *.test.out) 	\
   $(wildcard *.COVER.out)	\
+  $(wildcard *.COVER.html)	\
   $(wildcard TEST-*.xml)	\
   $(check_SCRIPTS)
 


### PR DESCRIPTION
tests/Makefile_dot_am: Add *.COVER.html to files to be removed on cleanup.
